### PR TITLE
refactor: rename cpp.type to cpp.name for externs

### DIFF
--- a/extern_types.module.yaml
+++ b/extern_types.module.yaml
@@ -10,7 +10,7 @@ externs:
       ue.namespace: "UE::Math"
       ue.module: "Engine"
       ### default initialization seems to be random and not zero -> test for default comparison fails
-      cpp.type: Vector3f
+      cpp.name: Vector3f
       cpp.include: "Eigen/StdVector"
       cpp.namespace: "Eigen"
       cpp.package: "Eigen3"
@@ -19,7 +19,7 @@ externs:
       cpp.conanpackage: "eigen"
       cpp.conanversion: "3.4.0"
       ### error: no match for ‘operator!=’ for Vec3f and no system package available
-      # cpp.type: Vec3f
+      # cpp.name: Vec3f
       # cpp.include: "gmtl/Vec.h"
       # cpp.namespace: "gmtl"
       # cpp.package: "gmtl"
@@ -27,14 +27,14 @@ externs:
       # cpp.conanpackage: "psyinf-gmtl"
       # cpp.conanversion: "0.7.1"
       ## working
-      # cpp.type: V3f
+      # cpp.name: V3f
       # cpp.include: "Imath/ImathVec.h"
       # cpp.namespace: "Imath"
       # cpp.package: "Imath"
       # cpp.conanpackage: "imath"
       # cpp.conanversion: "3.1.11"
       ## Qt test - working, but needs c++17
-      # cpp.type: QVector3D
+      # cpp.name: QVector3D
       # cpp.include: "QVector3D"
       # cpp.package: "Qt6"
       # cpp.component: "Gui"


### PR DESCRIPTION
## 📑 Description
Rename cpp.type to cpp.name for externs. The cli release uses cpp.name instead of type and thus it needs to be changed here.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->