### PR TITLE
ensure return is same as first param in operation

### DIFF
--- a/testbed.struct.module.yaml
+++ b/testbed.struct.module.yaml
@@ -19,7 +19,7 @@ interfaces:
         params:
           - { name: paramInt, type: StructInt }
         return:
-          type: StructBool #TODO: should be StructInt
+          type: StructInt
       - name: funcFloat
         params:
           - { name: paramFloat, type: StructFloat }
@@ -55,25 +55,25 @@ interfaces:
           - { name: paramBool, type: StructBool, array: true }
         return:
           type: StructBool
-          array: false #TODO: should be true
+          array: true
       - name: funcInt
         params:
           - { name: paramInt, type: StructInt, array: true }
         return:
-          type: StructBool #TODO: should be StructInt
-          array: false #TODO: should be true
+          type: StructInt
+          array: true
       - name: funcFloat
         params:
           - { name: paramFloat, type: StructFloat, array: true }
         return:
-          type: StructBool #TODO: should be StructFloat
-          array: false #TODO: should be true
+          type: StructFloat
+          array: true
       - name: funcString
         params:
           - { name: paramString, type: StructString, array: true }
         return:
-          type: StructBool #TODO: should be StructString
-          array: false #TODO: should be true
+          type: StructString
+          array: true
     signals:
       - name: sigBool
         params:
@@ -100,4 +100,3 @@ structs:
   - name: StructString
     fields:
       - { name: fieldString, type: string }
-


### PR DESCRIPTION
All return types on operations shall have the same type as the first function parameter. This will ensure later to write a generic reply server. 